### PR TITLE
Support SSL for internal OpenShift cluster (#1)

### DIFF
--- a/elastic-push.py
+++ b/elastic-push.py
@@ -5,6 +5,7 @@ import json
 parser = ArgumentParser()
 parser.add_argument("-f", "--file", dest="filename", help="write report to FILE", metavar="FILE")
 parser.add_argument("-s", "--server", dest="server", help="server name or IP of elastic search")
+
 args = parser.parse_args()
 
 f = open(args.filename,"r")
@@ -20,7 +21,14 @@ time = json_data['time']
 fio_version = json_data['fio version']
 
 # setup the elasticsearch connection
-es = Elasticsearch([{'host':args.server,'port':'9200'}])
+es = Elasticsearch(
+  [args.server],
+  use_ssl=True,
+  verify_certs=True,
+  ca_certs='/elasticsearch/ca',
+  client_cert='/elasticsearch/cert',
+  client_key='/elasticsearch/key'
+  )
 
 # add the job and disk_util details to each job before we send it
 for i in range(count):

--- a/openshift-setup/cronjob.yaml
+++ b/openshift-setup/cronjob.yaml
@@ -35,8 +35,8 @@ spec:
                 randwrite-16k-all.fio randwrite-4k-all.fio seqwrite-16k-all.fio seqwrite-4k-all.fio
                 randwrite-4k-io64-all.fio seqwrite-4k-io64-all.fio
             - name: ES_SERVER
-              value: <elasticsearchIp>
-            image: docker-registry.default.svc:5000/fio-elastic/fio-elastic
+              value: logging-es.openshift-logging.svc.cluster.local
+            image: docker-registry.default.svc:5000/portworxbenchmarking/fio-elastic
             imagePullPolicy: Always
             name: fio-container
             resources: {}
@@ -59,6 +59,9 @@ spec:
               name: fio-data-pwx-r1-med-rwo
             - mountPath: /fio-data-pwx-r3-med-rwo
               name: fio-data-pwx-r3-med-rwo
+            - mountPath: /elasticsearch
+              name: elasticsearch
+              readOnly: true
           dnsPolicy: ClusterFirst
           restartPolicy: Never
           schedulerName: default-scheduler
@@ -87,7 +90,11 @@ spec:
           - name: fio-data-pwx-r3-med-rwo
             persistentVolumeClaim:
               claimName: fio-data-pwx-r3-med-rwo
-  schedule: '@hourly'
+          - name: elasticsearch
+            secret:
+              defaultMode: 420
+              secretName: elasticsearch
+  schedule: "@hourly"
   successfulJobsHistoryLimit: 3
   suspend: false
 status: {}


### PR DESCRIPTION
This relies on a secret existing in the benchmarking project named "elasticsearch" and containing keys:

- ca
- cert
- key